### PR TITLE
improvement(next.js): change plugins order & unify syntax

### DIFF
--- a/components/CheckboxDemo.js
+++ b/components/CheckboxDemo.js
@@ -1,0 +1,19 @@
+import React, { useState } from 'react'
+import { Checkbox } from 'insites-ui'
+
+const CheckboxDemo = () => {
+  const [isChecked, setChecked] = useState(true)
+  const toggle = () => setChecked(!isChecked)
+
+  return (
+    <Checkbox
+      id="rememberMe"
+      checked={isChecked}
+      onChange={toggle}
+    >
+      Remember me
+    </Checkbox>
+  )
+}
+
+export default CheckboxDemo

--- a/components/RadioDemo.js
+++ b/components/RadioDemo.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+import { Box, Radio } from 'insites-ui'
+
+const RadioDemo = () => {
+  const [size, setSize] = useState('L')
+  const setSizeL = () => setSize('L')
+  const setSizeXL = () => setSize('XL')
+
+  return (
+    <>
+      <Box mb="2">
+        <Radio
+          id="sizeL"
+          checked={size === 'L'}
+          onChange={setSizeL}
+        >
+          Size L
+        </Radio>
+      </Box>
+      <Radio
+        id="sizeXL"
+        checked={size === 'XL'}
+        onChange={setSizeXL}
+      >
+        Size XL
+      </Radio>
+    </>
+  )
+}
+
+export default RadioDemo

--- a/content/form/checkbox.mdx
+++ b/content/form/checkbox.mdx
@@ -3,20 +3,14 @@ title: Checkbox
 description: ""
 ---
 
-import { Checkbox } from 'insites-ui'
 import DemoBox from '../../components/DemoBox'
+import CheckboxDemo from '../../components/CheckboxDemo'
 
 The checkbox is an additional control, that fits perfectly "Remember me" and
 accept agreements or conditions function.
 
 <DemoBox>
-    <Checkbox
-      id="rememberMe"
-      checked={true}
-      onChange={() => {}}
-    >
-      Remember me
-    </Checkbox>
+  <CheckboxDemo />
 </DemoBox>
 
 ```jsx

--- a/content/form/radio.mdx
+++ b/content/form/radio.mdx
@@ -3,39 +3,24 @@ title: Radio
 description: ""
 ---
 
-import { Radio, Box } from 'insites-ui'
 import DemoBox from '../../components/DemoBox'
+import RadioDemo from '../../components/RadioDemo'
 
-The checkbox is an additional control, that fits perfectly "Remember me" and
-accept agreements or conditions function.
+The radio is an additional control, that should be used when user
+is supposed to make only one selection out of a group of options.
 
 <DemoBox>
-    <Radio
-      id="rememberMe"
-      checked={true}
-      onChange={() => {}}
-    >
-      Size L
-    </Radio>
-    <Box mt="1rem">
-        <Radio
-          id="rememberMe"
-          checked={false}
-          onChange={() => {}}
-        >
-          Size XL
-        </Radio>
-    </Box>
+  <RadioDemo />
 </DemoBox>
 
 ```jsx
 import { Radio } from 'insites-ui'
 
 <Radio
-  id="rememberMe"
+  id="sizeL"
   checked={isChecked}
-  onChange={toggle}
+  onChange={check}
 >
-  Remember me
+  Size L
 </Radio>
 ```

--- a/content/framework-specific/next.mdx
+++ b/content/framework-specific/next.mdx
@@ -13,27 +13,27 @@ Update your `next.config.js` to look like this:
 
 ```jsx
 // /next.config.js
-const withImages = require('next-images');
+const withImages = require('next-images')
 const withTM = require('next-transpile-modules')([
   'styled-components',
-  'insites-ui',
-]);
+  'insites-ui'
+])
 
-module.exports = withTM(withImages());
+module.exports = withImages(withTM())
 ```
 
 And your `_app.js` to look like this:
 
 ```jsx
 // /pages/_app.js
-import { ThemeProvider, theme } from 'insites-ui';
-import 'typeface-inter';
+import { ThemeProvider, theme } from 'insites-ui'
+import 'typeface-inter'
 
 export default function CustomApp({ Component, pageProps }) {
   return (
     <ThemeProvider theme={theme}>
       <Component {...pageProps} />
     </ThemeProvider>
-  );
+  )
 }
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,13 +2784,14 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
-  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+  version "6.12.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.1.tgz#cce4d7dfcd62d3c57b1cd772e688eff5f5cd3839"
+  integrity sha512-AUh2mDlJDAnzSRaKkMHopTD1GKwC1ApUq8oCzdjAOM5tavncgqWU+JoRu5Y3iYY0Q/euiU+1LWp0/O/QY8CcHw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    opencollective-postinstall "^2.0.2"
     uri-js "^4.2.2"
 
 alphanum-sort@^1.0.0:
@@ -4144,9 +4145,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039:
-  version "1.0.30001042"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz#c91ec21ec2d270bd76dbc2ce261260c292b8c93c"
-  integrity sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw==
+  version "1.0.30001043"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001043.tgz#1b561de27aefbe6ff99e41866b8d7d87840c513b"
+  integrity sha512-MrBDRPJPDBYwACtSQvxg9+fkna5jPXhJlKmuxenl/ml9uf8LHKlDmLpElu+zTW/bEz7lC1m0wTDD7jiIB+hgFg==
 
 caniuse-lite@^1.0.30000989:
   version "1.0.30001041"
@@ -9658,9 +9659,9 @@ inquirer@^7.0.0:
     through "^2.3.6"
 
 insites-ui@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/insites-ui/-/insites-ui-0.2.0.tgz#978c16443451de54af016d032ffc047a6e08bcea"
-  integrity sha512-y+9uhUMBS3udjYpz51sek5MHq8tRGq+KvpPT5uHLHTrpsJhGN2ryR0e2sQdLNZOh1ZtKj7dxadFftw1cfA0uRw==
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/insites-ui/-/insites-ui-0.2.2.tgz#455848ca0f308120f0bd65b6b3e80cefa42a677f"
+  integrity sha512-8ZOXGwRN1/a07ibuRgOVzN4XYjYLNsSndrvQGHHhejXpXkJwzwo859ozK1LhoPOX5U51XyIv4Qv2c5qmvyo5zQ==
   dependencies:
     "@types/node" "^13.11.1"
     "@types/react" "^16.9.34"
@@ -12836,6 +12837,11 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+opencollective-postinstall@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
+  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
 opentracing@^0.14.4:
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.4.tgz#a113408ea740da3a90fde5b3b0011a375c2e4268"
@@ -13577,9 +13583,9 @@ polished@^2.3.3:
     "@babel/runtime" "^7.2.0"
 
 polished@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.5.1.tgz#657b6faf4c2308f3e0b1951196803a5e5d67b122"
-  integrity sha512-GVbvskpBiDV5TknurGL6OyFfLHsCknxbU8w5iMppT8rW0tLEoQHrIRfrPNPqGXNj3HGhkjRvhmg59Fy7HSnCAw==
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.5.2.tgz#ca132b8cd68f7ffa95ae9d423f03e7a14fda1062"
+  integrity sha512-vWoRDg3gY5RQBtUfcj9MRN10VCIf4EkdUikGxyXItg2Hnwk+eIVtdBiLajN0ldFeT3Vq4r/QNbjrQdhqBKrTug==
   dependencies:
     "@babel/runtime" "^7.8.7"
 
@@ -16458,9 +16464,9 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     urix "^0.1.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
-  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.17.tgz#29fe1b3c98b9dbd5064ada89052ee8ff070cb46c"
+  integrity sha512-bwdKOBZ5L0gFRh4KOxNap/J/MpvX9Yxsq9lFDx65s3o7F/NiHy7JRaGIS8MwW6tZPAq9UXE207Il0cfcb5yu/Q==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
With regard to [next-transpile-modules documentation ](https://www.npmjs.com/package/next-transpile-modules/v/2.3.0) I've decided to swap the order of plugins, so the `withTM` plugin is the most nested one. Also, I made some modifications in syntax to maintain consistency with other docs.